### PR TITLE
Fix UB on non-void RoboClaw::read function

### DIFF
--- a/RoboClaw.cpp
+++ b/RoboClaw.cpp
@@ -143,6 +143,7 @@ int RoboClaw::read(uint32_t timeout)
 		}
 	}
 #endif
+	return -1;
 }
 
 void RoboClaw::clear()


### PR DESCRIPTION
I've faced this UB when `sserial->isListening()` is false.

This keeps the standard of returning -1.